### PR TITLE
Replace '_' by '-' in package name, and viceversa for lib name

### DIFF
--- a/src/cabal.rs
+++ b/src/cabal.rs
@@ -2,6 +2,9 @@ use crate::Args;
 
 /// Generate user `.cabal`, taking `--enable-nix` option into account
 pub(crate) fn generate(name: &str, module: &str, version: &str, args: &Args) -> String {
+    let lib_name = name.replace("-", "_"); // When a lib is created, "-" is replaced by "_"
+    let package_name = name.replace("_", "-"); // cabal does not expect "_" for packages names
+
     let build_type = if args.enable_nix {
         "
 build-type:         Simple"
@@ -19,7 +22,7 @@ custom-setup
     -- `haskell.nix` tell GHC linker where to find the `libNAME.a` by setting
     -- automatically `extra-lib-dirs`:
     -- https://input-output-hk.github.io/haskell.nix/tutorials/pkg-map.html
-    extra-libraries:  {name}
+    extra-libraries:  {lib_name}
 
     -- Cross-compilation to target `x86_64-w64-mingw32-cc` thrown a lot of
     -- `undefined reference to 'X'` errors during linking stage ...
@@ -34,7 +37,7 @@ custom-setup
         format!(
             "
     -- Libraries that are bundled with the package.
-    extra-bundled-libraries: {name}"
+    extra-bundled-libraries: {lib_name}"
         )
     };
 
@@ -51,7 +54,7 @@ custom-setup
 -- documentation, see: http://haskell.org/cabal/users-guide/
 --
 -- The name of the package.
-name:               {name}
+name:               {package_name}
 
 -- The package version.
 -- See the Haskell package versioning policy (PVP) for standards

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,7 @@ fn routine() -> Result<(), Error> {
 
     // `.hsbindgen` is a config file readed by `#[hs_bindgen]` proc macro ...
     fs::write(".hsbindgen", hsbindgen::generate(&module))
-        .map_err(|_| Error::FailedToWriteFile(".hsbindgen".to_owned()))?;
+        .or(Err(Error::FailedToWriteFile(".hsbindgen".to_owned())))?;
 
     // If `crate-type = [ "cdylib" ]` then a custom `build.rs` is needed ...
     if crate_type == CrateType::DynLib {


### PR DESCRIPTION
If '-' is used in the crate name, when compiled to a static lib, rustc replaces it with '_', and cabal does not find the library. Similarly, if we use '_' in the crate name, cabal build complains when using underscore as the package name. 

```
sha3_bindings.cabal:13:25: error:
unexpected '_'
expecting white space or end of input
```